### PR TITLE
set bottom nav item color to white

### DIFF
--- a/app/src/main/res/drawable/dashboard_selector.xml
+++ b/app/src/main/res/drawable/dashboard_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_dashboard_inactive" android:state_checked="false"  />
+    <item  android:drawable="@drawable/ic_dashboard_black_24dp" android:state_checked="true" />
+</selector>

--- a/app/src/main/res/drawable/home_selector.xml
+++ b/app/src/main/res/drawable/home_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_home_inactive" android:state_checked="false"  />
+    <item  android:drawable="@drawable/ic_home_black_24dp" android:state_checked="true" />
+</selector>

--- a/app/src/main/res/drawable/ic_dashboard_inactive.xml
+++ b/app/src/main/res/drawable/ic_dashboard_inactive.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,5v2h-4L15,5h4M9,5v6L5,11L5,5h4m10,8v6h-4v-6h4M9,17v2L5,19v-2h4M21,3h-8v6h8L21,3zM11,3L3,3v10h8L11,3zM21,11h-8v10h8L21,11zM11,15L3,15v6h8v-6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home_inactive.xml
+++ b/app/src/main/res/drawable/ic_home_inactive.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,5.69l5,4.5V18h-2v-6H9v6H7v-7.81l5,-4.5M12,3L2,12h3v8h6v-6h2v6h6v-8h3L12,3z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,6 +12,8 @@
         android:layout_marginStart="0dp"
         android:layout_marginEnd="0dp"
         android:background="?android:attr/windowBackground"
+        app:itemIconTint="@color/white"
+        app:itemTextColor="@color/white"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -3,12 +3,12 @@
 
     <item
         android:id="@+id/navigation_home"
-        android:icon="@drawable/ic_home_black_24dp"
+        android:icon="@drawable/home_selector"
         android:title="@string/title_home" />
 
     <item
         android:id="@+id/navigation_dashboard"
-        android:icon="@drawable/ic_dashboard_black_24dp"
+        android:icon="@drawable/dashboard_selector"
         android:title="@string/title_dashboard" />
 
 </menu>


### PR DESCRIPTION
# Description

The Bottom Navigation items is not visible in light theme as the background color is black

- Fixes #3 


# Summary of changes:

-Change the color of bottom navigation items to white
-used selector to know active and inactive status of items in bottom navigation bar

# How has been tested ?
Tested on Physical Device (Realme 9)


https://user-images.githubusercontent.com/65113071/232760827-76b9bf06-5d43-4da4-9185-fdecad8c8ab4.mp4



# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.